### PR TITLE
商品管理エラーメッセージ日本語化

### DIFF
--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -12,7 +12,7 @@ class Item < ApplicationRecord
     validates :info, length: { maximum: 1000 }
     validates :category_id, :state_id, :shipping_fee_status_id,
               :prefecture_id, :scheduled_delivery_id,
-              numericality: { other_than: 1, message: "can't be blank" }
+              numericality: { other_than: 1, message: "を入力してください" }
     validates :price, numericality: {
       greater_than_or_equal_to: 300,
       less_than_or_equal_to: 9_999_999,

--- a/spec/support/blank_check_support.rb
+++ b/spec/support/blank_check_support.rb
@@ -14,9 +14,9 @@ module BlankCheckSupport
     hash[key] = 1
     hash.valid?
     if key.to_s.end_with?('_id')
-      expect(hash.errors.full_messages).to include(key.to_s.capitalize.chop.chop.chop.gsub(/_/, ' ') + ' ' + "can't be blank")
+      expect(hash.errors.full_messages).to include(key.to_s.capitalize.chop.chop.chop.gsub(/_/, ' ') + ' ' + "を入力してください")
     else
-      expect(hash.errors.full_messages).to include(key.to_s.capitalize.gsub(/_/, ' ') + ' ' + "can't be blank")
+      expect(hash.errors.full_messages).to include(key.to_s.capitalize.gsub(/_/, ' ') + ' ' + "を入力してください")
     end
   end
 end


### PR DESCRIPTION
category_id, state_id, shipping_fee_status_id, prefecture_id, scheduled_delivery_idの
can't be blank を日本語化